### PR TITLE
feat(pkg): Get Vulnrichment URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # vulnrichment
+
+library for [vulnrichment](https://github.com/cisagov/vulnrichment)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Pueringni3/vulnrichment
+
+go 1.21.6

--- a/main.go
+++ b/main.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	zipURL    string = "https://github.com/cisagov/vulnrichment/archive/refs/heads/develop.zip"
+	branchURL string = "https://github.com/cisagov/vulnrichment/tree/develop/"
+)
+
+func main() {
+	bs, err := fetch(zipURL)
+	if err != nil {
+		panic(err)
+	}
+
+	r, err := zip.NewReader(bytes.NewReader(bs), int64(len(bs)))
+	if err != nil {
+		panic(err)
+	}
+
+	pathMap := map[string]string{}
+	for _, zf := range r.File {
+		if !zf.FileInfo().IsDir() {
+			parts := strings.SplitN(zf.Name, "/", 2)
+			if len(parts) == 0 {
+				continue
+			}
+			fileName := filepath.Base(parts[1])
+			cveID := strings.TrimSuffix(fileName, ".json")
+			pathMap[cveID] = branchURL + parts[1]
+		}
+	}
+	fmt.Printf("pathmap: %v", pathMap["CVE-2024-8742"])
+}
+
+func fetch(url string) (body []byte, err error) {
+	httpClient := http.Client{}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("fetch failed")
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch failed")
+	}
+	defer resp.Body.Close()
+
+	buf, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read failed")
+	}
+
+	return buf, nil
+}


### PR DESCRIPTION
## 概要

- vulnrichment のレポジトリを parse して、該当の cve 情報が掲載されている URL を取得する

## 実行結果

`fmt.Printf("pathmap: %v", pathMap["CVE-2024-8742"])`

```
pathmap: https://github.com/cisagov/vulnrichment/tree/develop/2024/8xxx/CVE-2024-8742.json
```

## 要修正

- 適切に関数化する
- unit test の追加
- map で返すかの検討
- 処理遅いのでなんとかしたい（redis とかに入れる？）